### PR TITLE
Remove check to ignore ADMs over 4

### DIFF
--- a/src/main/java/com/bravebucks/eve/service/WalletParser.java
+++ b/src/main/java/com/bravebucks/eve/service/WalletParser.java
@@ -108,10 +108,6 @@ public class WalletParser {
                             continue;
                         }
                         final double adm = admService.getAdm(systemId);
-                        // this will let the adm get up to 4 before skipping the system
-                        if (adm > 4.0) {
-                            continue;
-                        }
 
                         final String[] killSplit = walletEntry.getReason().split(",");
                         int killCount = 0;


### PR DESCRIPTION
With structure anchoring changes, ADMs need to be 4.1+ to stop medium anchorings